### PR TITLE
new zen url

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nur.url = "github:nix-community/NUR";
-    zen-browser.url = "github:MarceColl/zen-browser-flake";
+    zen-browser.url = "git+https://git.sr.ht/~canasta/zen-browser-flake/"; # updated flake
   };
 
   outputs = inputs@{ nixpkgs, ... }: {


### PR DESCRIPTION
The current one is stale, here's an updated flake.

source: https://git.sr.ht/~canasta/zen-browser-flake