### PR TITLE
Remove mentions of `system` in `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,6 @@
       nixy =
         # CHANGEME: This should match the 'hostname' in your variables.nix file
         nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
           modules = [
             {
               nixpkgs.overlays = [ inputs.hyprpanel.overlay ];
@@ -55,7 +54,6 @@
         };
       # Jack is my server
       jack = nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
         modules = [
           { _module.args = { inherit inputs; }; }
           inputs.home-manager.nixosModules.home-manager


### PR DESCRIPTION
It's a legacy alias of `nixpkgs.hostPlatform`[^1], which is already set in each host's `hardware-configuration.nix` files. It will also be straight-up ignored if `nixpkgs.hostPlatform` is set.

(This is my first GitHub PR, so let me know if I've messed up :D)

[^1]: https://github.com/NixOS/nixpkgs/blob/837ff226bbd44c29303611703a4085d48f0957c9/flake.nix#L61