### PR TITLE
Update systemd extraConfig to rfc 42

### DIFF
--- a/nixos/systemd-boot.nix
+++ b/nixos/systemd-boot.nix
@@ -38,5 +38,5 @@
   };
 
   # To avoid systemd services hanging on shutdown
-  systemd.extraConfig = "DefaultTimeoutStopSec=10s";
+  systemd.settings.Manager = { DefaultTimeoutStopSec = "10s"; };
 }


### PR DESCRIPTION
According to: https://github.com/NixOS/nixpkgs/pull/426692

Otherwise after updating to latest version it will crash with error message:
" - The option definition `systemd.extraConfig' in ... no longer has any effect; please remove it.
Use systemd.settings.Manager instead."

As long as the flake is not updated this change is not necessary.
I'm not really sure if the config will build with this change before updating? 
Just a heads up for when it's updated though.